### PR TITLE
feat: btc get xpubs send in chunks

### DIFF
--- a/proto/btc/get_xpubs.proto
+++ b/proto/btc/get_xpubs.proto
@@ -25,6 +25,9 @@ message GetXpubsIntiateRequest {
   repeated GetXpubDerivationPath derivation_paths = 2;
 }
 
+message GetXpubsFetchNextRequest {
+}
+
 message GetXpubsResultResponse {
   repeated string xpubs = 1;
 }
@@ -32,6 +35,7 @@ message GetXpubsResultResponse {
 message GetXpubsRequest {
   oneof request {
     GetXpubsIntiateRequest initiate = 1;
+    GetXpubsFetchNextRequest fetch_next = 2;
   }
 }
 

--- a/proto/btc/get_xpubs.proto
+++ b/proto/btc/get_xpubs.proto
@@ -3,6 +3,17 @@ syntax = "proto3";
 import "error.proto";
 
 package btc;
+/**
+ * Example of successful xpub generation
+ *
+ *        Host                       Card
+ * GetXpubsIntiateRequest  =>
+ *                            <= GetXpubsResultResponse (1-10 xpubs)
+ * GetXpubsFetchNextRequest =>
+ *                            <= GetXpubsResultResponse (11-20 xpubs)
+ * GetXpubsFetchNextRequest =>
+ *                            <= GetXpubsResultResponse (21-30 xpubs)
+ */
 
 enum GetXpubsStatus {
   GET_XPUBS_STATUS_INIT = 0;

--- a/proto/btc/get_xpubs.proto
+++ b/proto/btc/get_xpubs.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 
-import "common.proto";
 import "error.proto";
 
 package btc;
@@ -14,7 +13,7 @@ enum GetXpubsStatus {
 }
 
 message GetXpubDerivationPath {
-  repeated common.DerivationPath path = 1;
+  repeated uint32 path = 1;
 }
 
 message GetXpubsIntiateRequest {

--- a/proto/btc/get_xpubs.proto
+++ b/proto/btc/get_xpubs.proto
@@ -6,7 +6,7 @@ package btc;
 /**
  * Example of successful xpub generation
  *
- *        Host                       Card
+ *        Host                       Device
  * GetXpubsIntiateRequest  =>
  *                            <= GetXpubsResultResponse (1-10 xpubs)
  * GetXpubsFetchNextRequest =>

--- a/proto/error.proto
+++ b/proto/error.proto
@@ -51,18 +51,34 @@ enum UserRejection {
 }
 
 enum DataFlow {
+  /* protobuf decoding by nanopb api failed */
   DATA_FLOW_DECODING_FAILED = 0; // will this cover situation of enum out of range?
 
-  /* query received is: invalid or is of different app_function (eg. device auth in between get logs) */
+  /* query received is: invalid or is of different app_function (eg. device
+   * auth in between get logs)
+   */
   DATA_FLOW_INVALID_QUERY = 1;
+
+  /* protobuf `optional` fields when checked on receiving end was absent. */
   DATA_FLOW_FIELD_MISSING = 2;
 
-  /* Wrong request is received in app_function */
+  /* Wrong request is received in app_function. could be at start of flow
+   * or in-between the flow
+   */
   DATA_FLOW_INVALID_REQUEST = 3;
+
+  /* inactivity during wait-for-data from host. In-between a flow */
   DATA_FLOW_INACTIVITY_TIMEOUT = 4;
+
+  /* when the flow specific data validity fails. could be at start of flow
+   * or in-between the flow
+   */
   DATA_FLOW_INVALID_DATA = 5;
-  /* query received is: when app in unserviceable state (eg. export wallet request before on-boarding,
-     export wallet request on unauthenticated device on main */
+
+  /* query received is: when app in unserviceable state (eg. export wallet
+   * request before on-boarding, export wallet request on unauthenticated
+   * device on main
+   */
   DATA_FLOW_QUERY_NOT_ALLOWED = 6;
 }
 

--- a/proto/error.proto
+++ b/proto/error.proto
@@ -61,6 +61,7 @@ enum DataFlow {
   /* Wrong request is received in app_function */
   DATA_FLOW_INVALID_REQUEST = 3;
   DATA_FLOW_INACTIVITY_TIMEOUT = 4;
+  DATA_FLOW_INVALID_DATA = 5;
 }
 
 message CommonError {

--- a/proto/error.proto
+++ b/proto/error.proto
@@ -53,8 +53,7 @@ enum UserRejection {
 enum DataFlow {
   DATA_FLOW_DECODING_FAILED = 0; // will this cover situation of enum out of range?
 
-  /* query received is: invalid or when in unserviceable state or of different
-   app_function */
+  /* query received is: invalid or is of different app_function (eg. device auth in between get logs) */
   DATA_FLOW_INVALID_QUERY = 1;
   DATA_FLOW_FIELD_MISSING = 2;
 
@@ -62,6 +61,9 @@ enum DataFlow {
   DATA_FLOW_INVALID_REQUEST = 3;
   DATA_FLOW_INACTIVITY_TIMEOUT = 4;
   DATA_FLOW_INVALID_DATA = 5;
+  /* query received is: when app in unserviceable state (eg. export wallet request before on-boarding,
+     export wallet request on unauthenticated device on main */
+  DATA_FLOW_QUERY_NOT_ALLOWED = 6;
 }
 
 message CommonError {

--- a/proto/manager/auth_card.proto
+++ b/proto/manager/auth_card.proto
@@ -7,7 +7,7 @@ package manager;
 /**
  * Example of successful authentication
  *
- *        Host                       Card
+ *        Host                       Device
  * AuthCardInitiateRequest  => 
  *                            <= AuthCardSerialSigResponse
  * AuthCardChallengeRequest =>
@@ -19,7 +19,7 @@ package manager;
 /**
  * Example of failed authentication
  *
- *        Host                       Card
+ *        Host                       Device
  * AuthCardInitiateRequest  => 
  *                            <= AuthCardSerialSigResponse
  * AuthCardResult           =>

--- a/proto/manager/get_logs.proto
+++ b/proto/manager/get_logs.proto
@@ -7,7 +7,7 @@ package manager;
 /**
  * Example of successful authentication
  *
- *        Host                       Card
+ *        Host                       Device
  * GetLogsInitiateRequest  => 
  *                            <= GetLogsDataResponse (hasMore: true)
  * GetLogsFetchNextRequest =>


### PR DESCRIPTION
1. [refactor: Replace derivation path struct with uint32](https://github.com/Cypherock/cypherock-common/commit/a61865bcea4508276f5abc3c6191616424ca90ff) </br> The hardness flag is not required and the index value itself indicates the hardness in the according to BIP32. This also
 removes the need for a struct.
2. [chore: Add enum for invalid data](https://github.com/Cypherock/cypherock-common/commit/745d78d0270bb0786ea5a924800d48a27cd4d17b)
3. [chore: Add error enum for not allowed query](https://github.com/Cypherock/cypherock-common/commit/ef740da229db12eba9a8bfb91a052da508db3424)
4. [chore: Optimize response struct size for large request](https://github.com/Cypherock/cypherock-common/commit/af57dfffa91f11e0a4b7eba7b62c004a3c4df71b) </br> Current response mechanism limits the request size to 50 (as the 6kB limit at USB buffer puts an upper cap). Paginating the response extends this limit even further. Although there will always be an upper limit (currently increased to 100) to how much can be requested in a single request.