### PR TITLE
feat: Add proto enum to convey timeout exits from the device to host

### DIFF
--- a/proto/core.proto
+++ b/proto/core.proto
@@ -34,6 +34,8 @@ enum ErrorType {
   INVALID_MSG = 2;
   /** Cannot start app as other app is running */
   APP_NOT_ACTIVE = 3;
+  /** Timeout occured during an app */
+  APP_TIMEOUT_OCCURRED = 4;
 };
 
 message ErrorCmd {


### PR DESCRIPTION
The enum will be sent to the host to notify that the app flow has been exited due to inactivity timeout. The reason for inactivity can be:
- User inactivity on confirmation screens/ error screens
- Inactivity due to timeout while waiting for subsequent USB messages during the flow.

The response will be sent at the core level.